### PR TITLE
Fix font 404 error and Vue component error

### DIFF
--- a/resources/js/Pages/Form/Error.vue
+++ b/resources/js/Pages/Form/Error.vue
@@ -7,7 +7,7 @@ const props = defineProps({
 const form = props.form;
 
 const page = usePage();
-const flashMessage = page.props.flash.error || "";
+const flashMessage = page.props.flash?.error || "";
 const formattedMessage = flashMessage.replace(/\n/g, "<br>");
 if (!formattedMessage) {
   form.post(route("viewer"));

--- a/resources/scss/main.scss
+++ b/resources/scss/main.scss
@@ -14,7 +14,7 @@ $fa-font-path: "@fortawesome/fontawesome-free/webfonts" !default;
 @font-face {
   font-family: "Noto Sans JP";
   font-display: swap;
-  src: url("/public/assets/fonts/Noto_Sans_JP/NotoSansJP-VariableFont_wght.ttf") format("truetype");
+  src: url("../../../public/assets/fonts/Noto_Sans_JP/NotoSansJP-VariableFont_wght.ttf") format("truetype");
   font-weight: 100 900;
   font-size: normal;
 }


### PR DESCRIPTION
## Summary
- フォントファイルの404エラーを修正
- Vueコンポーネントのエラーを修正
- アプリケーション起動時のエラーを解消

## Changes
1. **Error.vueの修正**
   - `page.props.flash.error` にオプショナルチェイニングを追加
   - `flash`がundefinedの場合でもエラーが発生しないように修正

2. **main.scssの修正**
   - フォントファイルのパスを相対パスに変更
   - Viteがフォントファイルを正しく解決できるように修正

3. **フォントファイルの追加**
   - Noto Sans JPフォントファイルを`public/assets/fonts/`に配置
   - 404エラーを解消

## Test plan
- [x] `npm run dev`でVite開発サーバーを起動
- [x] ブラウザコンソールでエラーが表示されないことを確認
- [x] フォントが正しく読み込まれることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)